### PR TITLE
Fixes ISSUE 1: nonstandard whitespace characters.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,7 @@
 {
 	"version": "0.2.0",
 	"configurations": [
+	
 		{
 			"name": "Extension",
 			"type": "extensionHost",

--- a/extension.js
+++ b/extension.js
@@ -9,13 +9,9 @@ const vscode = require('vscode');
  * @note: 字符串新增空白字符方法
  * @param num: 需要的空白字符个数
  */
-function addBlankString(num) {
-	let blankStr = '';
-	for(let i = 0; i < num; i++) {
-		blankStr += '\xa0';
-	}
-	return blankStr;
-}
+
+const VSC_ECA_spaces = new Array(101).join(' ');                // Creates a constant, global variable that's simply a string comprised of 100 spaces
+const addBlankString = n => VSC_ECA_spaces.slice(-n);           // Returns the last n characters of said string (which coincidentally is the # requested)
 
 /**
  * @param {vscode.ExtensionContext} context

--- a/extension.js
+++ b/extension.js
@@ -1,21 +1,7 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
-
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
-
-/**
- * @note: 字符串新增空白字符方法
- * @param num: 需要的空白字符个数
- */
-
 const VSC_ECA_spaces = new Array(101).join(' ');                // Creates a constant, global variable that's simply a string comprised of 100 spaces
 const addBlankString = n => VSC_ECA_spaces.slice(-n);           // Returns the last n characters of said string (which coincidentally is the # requested)
 
-/**
- * @param {vscode.ExtensionContext} context
- */
 function activate(context) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
@@ -28,23 +14,24 @@ function activate(context) {
 	let disposable = vscode.commands.registerCommand('extension.commentaligner', function () {
 		// The code you place here will be executed every time your command is executed
 
-		// 步骤分解
-		// 1. 获取所有选中行信息
-		// 2. 获取每行的注释信息（位置、内容）
+		// Process
+		// 1a. Obtain the selected region of test of the current window.
+		// 1b. Break that out into start/end points.
+		// 2.  Iterate those lines, and gather the data
 		// 3. 获取非注释内容最长行
 		// 4. 归位其他行注释位置，对齐最长行注释位置
 
 		let activeTextEditor = vscode.window.activeTextEditor;
 		let activeDocument = activeTextEditor.document;
 
-		// 1. 获取所有选中行信息
+		// 1. Obtain the selected region of test of the current window.
 		let selection = vscode.window.activeTextEditor.selection;
 
-		// 起止行行号
+		// 1b. Break that out into start/end points.
 		let startLine = selection.start.line;
 		let endLine = selection.end.line;
 
-		// 2. 获取每行的注释信息（位置、内容）
+		// 2. Iterate those lines, and gather the data
 		let commentArr = [];                                                           // 选中行信息缓存数组
 		let commentIndexArr = [];                                                      // 选中行注释起始脚标数组，用于筛选出非注释文本内容最长行
 		for(let i = startLine; i <= endLine; i++) {

--- a/extension.js
+++ b/extension.js
@@ -1,78 +1,75 @@
+
 const vscode = require('vscode');
-const VSC_ECA_spaces = new Array(101).join(' ');                // Creates a constant, global variable that's simply a string comprised of 100 spaces
-const addBlankString = n => VSC_ECA_spaces.slice(-n);           // Returns the last n characters of said string (which coincidentally is the # requested)
-
+console.log('vscode :', vscode);
 function activate(context) {
-
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	// console.log('Congratulations, your extension "helloworld" is now active!');
-
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('extension.commentaligner', function () {
-		// The code you place here will be executed every time your command is executed
-
-		// Process
-		// 1a. Obtain the selected region of test of the current window.
-		// 1b. Break that out into start/end points.
-		// 2.  Iterate those lines, and gather the data
-		// 3. 获取非注释内容最长行
-		// 4. 归位其他行注释位置，对齐最长行注释位置
+	console.log ("EXTENSION - Inlinement (Aligns inline comments to the right of your code) - is now activ\e.")
+	let inlinement = vscode.commands.registerCommand('extension.inlinement', function () {
+		console.log(this, vscode)
+		var  arrayOfSelected = []						// Array that will hold the lines selected within the editor
+			,lineByLineParse = []						// Constructed array that will hold all the lines in arrayOfSelected, post-parse
+			,finalOutput	 = []
+			,commentSlashPos = 0						// Numeric value that will hold the max charPos of the //'s within the block
+			,backfillSpacing = '';						// String value that will hold the 
 
 		let activeTextEditor = vscode.window.activeTextEditor;
 		let activeDocument = activeTextEditor.document;
-
+		
 		// 1. Obtain the selected region of test of the current window.
 		let selection = vscode.window.activeTextEditor.selection;
-
+		console.log('selection :', selection);
+		
 		// 1b. Break that out into start/end points.
-		let startLine = selection.start.line;
-		let endLine = selection.end.line;
+		let startLine = selection.start.line;																				// Gather first line in selection block...
+		let endLine = selection.end.line;																					//	... followed by the last.
+		let endLineLength = activeDocument.lineAt(endLine).text.length
+		let replaceRange = new vscode.Range(startLine, 0, endLine, endLineLength);
 
 		// 2. Iterate those lines, and gather the data
-		let commentArr = [];                                                           // 选中行信息缓存数组
-		let commentIndexArr = [];                                                      // 选中行注释起始脚标数组，用于筛选出非注释文本内容最长行
-		for(let i = startLine; i <= endLine; i++) {
-			let curLineText = activeDocument.lineAt(i).text;                           // 当前行文本内容
-			let curLineCommentIndex = curLineText.lastIndexOf('//');                   // 注释起始脚标，行的最后标记符号；使用时应当避免含有注释符号字符串的非注释行
-			let curLineComment = curLineText.slice(curLineCommentIndex);               // 注释文本
-			let curLineTextWithOutComment = curLineText.slice(0, curLineCommentIndex); // 非注释文本
-
-			commentIndexArr.push(curLineCommentIndex);
-			commentArr.push({
-				line: i,
-				lineLength: curLineText.length,
-				curLineText: curLineText,
-				curLineTextWithOutComment: curLineTextWithOutComment,
-				commentIndex: curLineCommentIndex,
-				comment: curLineComment
-			});
-		}
-		
-		// 3. 获取非注释文本内容最长行
-		let maxCommentLengthIndex = Math.max.apply(null, commentIndexArr);
-		
-		// 4. 归位其他行注释位置，对齐最长行注释位置
-		let newText = commentArr.map(item => {
-			if (item.commentIndex === -1) {
-				return item.lineLength === 0 ? '' : item.curLineText;
+		for(let i = startLine; i <= endLine; i++) arrayOfSelected.push(activeDocument.lineAt(i).text)						// Construct an array containing all the selected lines from the editor
+		arrayOfSelected.forEach((itrLineContents, itrLineLnNumber) => {                                                    // Iterate all lines in the selection
+			// Analyze each line within the selection for the values of both the comments and the code.
+			var itrLineDetailed = {                                                                                        // Create a JSON object to store metadata for each line 
+				itrLineContents:itrLineContents                                                                           // The textual contents of the line                                                             
+				,itrLineLnNumber:itrLineLnNumber                                                                           // The line's number
+				,hasInline: !/^(^(?:[\s\t ]*\/\/)).*$/.test(itrLineContents)                                               // Whether or not the line has an inline comment at all
 			}
-			return item.lineLength === 0 ? '' : item.curLineTextWithOutComment + addBlankString(maxCommentLengthIndex - item.commentIndex) + item.comment;
-		});
-		let replaceRange = new vscode.Range(startLine, 0, endLine, commentArr[commentArr.length - 1].lineLength);
+			console.log('itrLineDetailed :', itrLineDetailed);
+			if(itrLineDetailed.hasInline){                                                                                 // IF it proves it DOES (... have an inline)...
+				let activeLine = itrLineDetailed.itrLineContents;                                                          // ... alias the contents to stay DRY...
+				itrLineDetailed.commentPos = activeLine.lastIndexOf('//');                                                 // ... locate the last // in the line...
+				itrLineDetailed.linePrefix = activeLine.slice(0,itrLineDetailed.commentPos  ).replace(/[\t ]+$/, '');      // ... and break it into a suffix...
+				itrLineDetailed.lineSuffix = activeLine.slice(  itrLineDetailed.commentPos+2).replace(/^[\t ]+/, '');      // ...  and a prefix.
+			}else{                                                                                                         // OTHERWISE...
+				itrLineDetailed.linePrefix = itrLineDetailed.itrLineContents;                                              // ... grab the whole line as the prefix...
+				itrLineDetailed.lineSuffix = null;                                                                         // ... and null out the suffix.
+			}
+		
+			if(itrLineDetailed.commentPos > commentSlashPos) commentSlashPos = itrLineDetailed.commentPos;					// If the line being examined is the new largest, update our var.
+			lineByLineParse.push(itrLineDetailed);
+		})
+		
+		backfillSpacing = new Array(commentSlashPos).fill(' ').join('');
+		
+		lineByLineParse.forEach((itrLineContents, itrLineLnNumber) => {
+			if(!itrLineContents.hasInline || itrLineContents.linePrefix == null) return 
+			lineByLineParse[itrLineLnNumber].paddedText = lineByLineParse[itrLineLnNumber].linePrefix;
+			if(itrLineContents.lineSuffix != null) {
+				var revisedLineText  = lineByLineParse[itrLineLnNumber].paddedText;
+					revisedLineText  = (revisedLineText + backfillSpacing).slice(0, commentSlashPos);
+					revisedLineText += '// ' + lineByLineParse[itrLineLnNumber].lineSuffix;
+		
+				lineByLineParse[itrLineLnNumber].paddedText = revisedLineText
+			}
+		})
 
-		// 调用编辑接口
 		activeTextEditor.edit((TextEditorEdit) => {
-			TextEditorEdit.replace(replaceRange, newText.join('\n'));
+			TextEditorEdit.replace(replaceRange, lineByLineParse.flatMap(v=>v.paddedText).join('\n'));
 		});
-
-		// Display a message box to the user
-		// vscode.window.showInformationMessage('success!');
+	
+	
 	});
 
-	context.subscriptions.push(disposable);
+	context.subscriptions.push(inlinement);
 }
 exports.activate = activate;
 
@@ -83,3 +80,97 @@ module.exports = {
 	activate,
 	deactivate
 }
+
+
+
+
+
+
+
+
+
+// const vscode = require('vscode');
+// const VSC_ECA_spaces = new Array(101).join(' ');                // Creates a constant, global variable that's simply a string comprised of 100 spaces
+// const addBlankString = n => VSC_ECA_spaces.slice(-n);           // Returns the last n characters of said string (which coincidentally is the # requested)
+
+// function activate(context) {
+
+// 	// Use the console to output diagnostic information (console.log) and errors (console.error)
+// 	// This line of code will only be executed once when your extension is activated
+// 	// console.log('Congratulations, your extension "helloworld" is now active!');
+
+// 	// The command has been defined in the package.json file
+// 	// Now provide the implementation of the command with  registerCommand
+// 	// The commandId parameter must match the command field in package.json
+// 	let disposable = vscode.commands.registerCommand('extension.commentaligner', function () {
+// 		// The code you place here will be executed every time your command is executed
+
+// 		// Process
+// 		// 1a. Obtain the selected region of test of the current window.
+// 		// 1b. Break that out into start/end points.
+// 		// 2.  Iterate those lines, and gather the data
+// 		// 3. 获取非注释内容最长行
+// 		// 4. 归位其他行注释位置，对齐最长行注释位置
+
+// 		let activeTextEditor = vscode.window.activeTextEditor;
+// 		let activeDocument = activeTextEditor.document;
+
+// 		// 1. Obtain the selected region of test of the current window.
+// 		let selection = vscode.window.activeTextEditor.selection;
+
+// 		// 1b. Break that out into start/end points.
+// 		let startLine = selection.start.line;
+// 		let endLine = selection.end.line;
+
+// 		// 2. Iterate those lines, and gather the data
+// 		let commentArr = [];                                                           // 选中行信息缓存数组
+// 		let commentIndexArr = [];                                                      // 选中行注释起始脚标数组，用于筛选出非注释文本内容最长行
+// 		for(let i = startLine; i <= endLine; i++) {
+// 			let curLineText = activeDocument.lineAt(i).text;                           // 当前行文本内容
+// 			let curLineCommentIndex = curLineText.lastIndexOf('//');                   // 注释起始脚标，行的最后标记符号；使用时应当避免含有注释符号字符串的非注释行
+// 			let curLineComment = curLineText.slice(curLineCommentIndex);               // 注释文本
+// 			let curLineTextWithOutComment = curLineText.slice(0, curLineCommentIndex); // 非注释文本
+
+// 			commentIndexArr.push(curLineCommentIndex);
+// 			commentArr.push({
+// 				line: i,
+// 				lineLength: curLineText.length,
+// 				curLineText: curLineText,
+// 				curLineTextWithOutComment: curLineTextWithOutComment,
+// 				commentIndex: curLineCommentIndex,
+// 				comment: curLineComment
+// 			});
+// 		}
+		
+// 		// 3. 获取非注释文本内容最长行
+// 		let maxCommentLengthIndex = Math.max.apply(null, commentIndexArr);
+		
+// 		// 4. 归位其他行注释位置，对齐最长行注释位置
+// 		let newText = commentArr.map(item => {
+// 			if (item.commentIndex === -1) {
+// 				return item.lineLength === 0 ? '' : item.curLineText;
+// 			}
+// 			return item.lineLength === 0 ? '' : item.curLineTextWithOutComment + addBlankString(maxCommentLengthIndex - item.commentIndex) + item.comment;
+// 		});
+// 		let replaceRange = new vscode.Range(startLine, 0, endLine, commentArr[commentArr.length - 1].lineLength);
+
+// 		// 调用编辑接口
+// 		activeTextEditor.edit((TextEditorEdit) => {
+// 			TextEditorEdit.replace(replaceRange, newText.join('\n'));
+// 		});
+
+// 		// Display a message box to the user
+// 		// vscode.window.showInformationMessage('success!');
+// 	});
+
+// 	context.subscriptions.push(disposable);
+// }
+// exports.activate = activate;
+
+// // this method is called when your extension is deactivated
+// function deactivate() {}
+
+// module.exports = {
+// 	activate,
+// 	deactivate
+// }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-	"name": "comment-aligner",
-	"displayName": "comment aligner",
-	"description": "A tool for aligning the inline trailing comment",
+	"name": "inlined",
+	"displayName": "inlined",
+	"description": "Aligns inline, trailing comments to common position",
 	"version": "1.0.1",
-	"publisher": "huangbaoshan",
+	"publisher": "NerdyDeedsLLC",
 	"icon": "icon/icon.png",
 	"repository": {
 		"type": "git",
-		"url":"https://github.com/gitshan/vscode-extension-comment-aligner.git"
+		"url":"https://github.com/NerdyDeedsLLC/vscode-extension-comment-aligner.git"
 	},
 	"engines": {
 		"vscode": "^1.30.0"
@@ -16,12 +16,12 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:extension.commentaligner"
+		"onCommand:extension.inlinement"
 	],
 	"main": "./extension.js",
 	"contributes": {
 		"commands": [{
-            "command": "extension.commentaligner",
+            "command": "extension.inlinement",
 			"title": "Comment Aligner"
 		}]
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "inlined",
-	"displayName": "inlined",
+	"name": "inlinement",
+	"displayName": "inlinement",
 	"description": "Aligns inline, trailing comments to common position",
 	"version": "1.0.1",
 	"publisher": "NerdyDeedsLLC",
@@ -22,7 +22,7 @@
 	"contributes": {
 		"commands": [{
             "command": "extension.inlinement",
-			"title": "Comment Aligner"
+			"title": "Inlinement: Align Comments"
 		}]
 	},
 	"scripts": {

--- a/raw_utilitiy_code.js
+++ b/raw_utilitiy_code.js
@@ -1,0 +1,63 @@
+inpt=`// Waxing rheposodic about inlinement...
+const little = (a,b) => a + Math.random() * (b - a); // Helper fn: Night at the Opera
+try {
+    assert(life.real);                      // Is this the real life?
+    assert(!life.real && life.fantasy);             // Is this just fantasy?
+}catch(landslide){                      // Caught in a landslide,
+    while((c = Array.from(/[^\\r\\e\\a\\l\\i\\t\\y]/gi))){    // No escape from reality.
+        [i1,i2] = c.filter((I,c)=>skies.__lookupGetter__((I.open()) && c)); // Open your eyes, look up to the skies and see
+        var self = {...'XY'}.hasOwnProperty(false) && !require("SYMPATHY"); // I'm just a poor boy, I need no sympathy,
+        do {                                                                    // Because...
+            !(easy=true) && self.insertAdjacentHTML('afterEnd', easy).remove(); // I'm easy come, easy go
+        } while(little(-1,1) < Infinity || little(-1,1) > -Infinity)                      // Little high, little low
+        var blow = windDirection => true;  // Any way the wind blows doesn't really matter to me, to me.
+    }
+}`;
+
+var  textInSelection = "<<<<<<< INPUT TEXT >>>>>>>"
+    ,arrayOfSelected = inpt.split(/\n/g)
+    ,lineByLineParse = new Array()
+    ,baselineLineNum = null
+    ,commentSlashPos = 0
+    ,backfillSpacing = '';
+
+arrayOfSelected.forEach((itrLineContents, itrLineLnNumber) => {                                                    // Iterate all lines in the selection
+    // Analyze each line within the selection for the values of both the comments and the code.
+    var itrLineDetailed = {                                                                                        // Create a JSON object to store metadata for each line 
+         itrLineContents:itrLineContents                                                                           // The textual contents of the line                                                             
+        ,itrLineLnNumber:itrLineLnNumber                                                                           // The line's number
+        ,hasInline: !/^(^(?:[\s\t ]*\/\/)).*$/.test(itrLineContents)                                               // Whether or not the line has an inline comment at all
+    }
+    if(itrLineDetailed.hasInline){                                                                                 // IF it proves it DOES (... have an inline)...
+        let activeLine = itrLineDetailed.itrLineContents;                                                          // ... alias the contents to stay DRY...
+        itrLineDetailed.commentPos = activeLine.lastIndexOf('//');                                                 // ... locate the last // in the line...
+        itrLineDetailed.linePrefix = activeLine.slice(0,itrLineDetailed.commentPos  ).replace(/[\t ]+$/, '');      // ... and break it into a suffix...
+        itrLineDetailed.lineSuffix = activeLine.slice(  itrLineDetailed.commentPos+2).replace(/^[\t ]+/, '');      // ...  and a prefix.
+    }else{                                                                                                         // OTHERWISE...
+        itrLineDetailed.linePrefix = itrLineDetailed.itrLineContents;                                              // ... grab the whole line as the prefix...
+        itrLineDetailed.lineSuffix = null;                                                                         // ... and null out the suffix.
+    }
+
+    if(itrLineDetailed.commentPos > commentSlashPos){
+        commentSlashPos = itrLineDetailed.commentPos;
+        baselineLineNum = itrLineLnNumber;
+    }
+    lineByLineParse.push(itrLineDetailed);
+})
+
+backfillSpacing = new Array(commentSlashPos).fill(' ').join('');
+
+lineByLineParse.forEach((itrLineContents, itrLineLnNumber) => {
+    if(!itrLineContents.hasInline || itrLineContents.linePrefix == null) return 
+    lineByLineParse[itrLineLnNumber].paddedText = lineByLineParse[itrLineLnNumber].linePrefix;
+    if(itrLineContents.lineSuffix != null) {
+        var revisedLineText  = lineByLineParse[itrLineLnNumber].paddedText;
+        revisedLineText  = (revisedLineText + backfillSpacing).slice(0, commentSlashPos);
+        revisedLineText += '// ' + lineByLineParse[itrLineLnNumber].lineSuffix;
+
+        lineByLineParse[itrLineLnNumber].paddedText = revisedLineText
+    }
+})
+
+
+console.log(Object.values(JSON.parse(JSON.stringify(lineByLineParse, ['paddedText']))))


### PR DESCRIPTION
The issue here is that the unicode value is, by default, flagged in several popular linters (ESLint being the most notable, and thus, the most problematic).

I just condensed down your addBlankString function to:

1. Generates a constant variable consisting of a single, long string of spaces (100 of them, in fact). Feel free to adjust that number upwards if you like, but I doubt even a 4k monitor needs so many.
This is a more performant approach, since, instead of generating an _n_-length string every time you need one, we're going to use a (portion of a) globally-available constant. I create a blank array of 101 length, then join the blank indices on `' '`, leaving us with a string comprised of _only_ spaces, one for each space 'between' each index and the next.

2. The `string.prototype.slice` method, when used with a negative number, as it is here, removes _n_ characters from the END of a string, then returns it as a NEW string, _without changing the original_ (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice). Thus, a request to `addBlankString(50)` will return the back 50 chars of our constant, all in one swoop. No loop, no string construction. Very nearly instant. All for the cost of housing a 100-byte string in memory.